### PR TITLE
Update to manifest 3

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,0 @@
-function getPageDetails(callback) { 
-  chrome.tabs.executeScript(null, { file: 'content.js' });
-  chrome.runtime.onMessage.addListener(function(message)  {
-      callback(message);
-  });
-};

--- a/main.js
+++ b/main.js
@@ -261,7 +261,6 @@ function refreshHighlighter() {
 function readSettings() {
   chrome.storage.local.get(gDefaultSetting, function (items) {
     gConfigData = items;
-    checkNotification();
   });
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "48": "icon48.png",
     "128": "icon128.png"
   },
-  "version": "0.1.0.8",
+  "version": "0.1.1.0",
   "author": "@bipix",
   "permissions": [
     "activeTab",

--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,6 @@
         "module-modelmap.js",
         "module-tooltip.js",
         "module-snippet.js",
-        "module-notification.js",
         "main.js"
       ]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "A+ for Anaplan (Model Builder Edition)",
   "description": "Unofficial Chrome extension for a better Model Builder experience",
   "icons": {
@@ -11,8 +11,10 @@
   "author": "@bipix",
   "permissions": [
     "activeTab",
-    "https://*.app.anaplan.com/*",
     "storage"
+  ],
+  "host_permissions": [
+    "https://*.app.anaplan.com/*"
   ],
   "content_scripts": [
     {
@@ -38,10 +40,17 @@
     }
   ],
   "web_accessible_resources": [
-    "injected.js"
+    {
+      "resources": [
+        "injected.js"
+      ],
+      "matches": [ "https://*.app.anaplan.com/*" ]
+    }
   ],
-  "browser_action": {
-    "default_icon": "icon128.png",
+  "action": {
+    "default_icon": {
+      "128": "icon128.png"
+    },
     "default_title": "A+ for Anaplan",
     "default_popup": "popup.html"
   }

--- a/popup.html
+++ b/popup.html
@@ -3,8 +3,8 @@
 
 <head>
   <title>Formatting Formula</title>
-  <script type="text/javascript" src="constants.js"></script>
-  <script type="text/javascript" src="popup.js"></script>
+  <script type="text/javascript" src="./constants.js"></script>
+  <script type="text/javascript" src="./popup.js"></script>
   <style>
     .content-area{text-align: left; margin-left: 20px; margin-bottom: 10px; line-height: 15px; font-family: Helvetica; font-size: 11px;}
     .content-area input{display:inline-block; margin-bottom: 5px; font-family: Helvetica; font-size: 11px;}


### PR DESCRIPTION
As of January 17, 2022 the Chrome Web Store has stopped accepting new Manifest V2 extensions.

This pull request migrate the chrome extension to Manifest V3, following the migration guide from Google. https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/